### PR TITLE
world, level, and layer now create their own labeled load_context

### DIFF
--- a/src/layer.rs
+++ b/src/layer.rs
@@ -300,13 +300,17 @@ impl Layer {
         let identifier = value.identifier.clone();
         let layer_asset_path = level_asset_path.to_layer_asset_path(&identifier)?;
         let opacity = value.opacity;
+
+        let mut layer_load_context = load_context.begin_labeled_asset();
+
         let layer_type = LayerType::new(
             value,
             &layer_asset_path,
-            load_context,
+            &mut layer_load_context,
             project_context,
             project_definition_context,
         )?;
+
         let iid = Iid::from_str(&value.iid)?;
         let layer_definition = project_definition_context
             .layer_definitions
@@ -339,8 +343,9 @@ impl Layer {
             level_id,
             location,
             index,
-        }
-        .into();
+        };
+
+        let layer = layer_load_context.finish(layer, None);
 
         let handle =
             load_context.add_loaded_labeled_asset(layer_asset_path.to_asset_label(), layer);

--- a/src/level.rs
+++ b/src/level.rs
@@ -257,6 +257,8 @@ impl Level {
                     Are we opening the local layer definition instead of the external one?"
         ))?;
 
+        let mut level_load_context = load_context.begin_labeled_asset();
+
         let layers = layer_instances
             .iter()
             .rev()
@@ -266,7 +268,7 @@ impl Level {
                     ldtk_layer_instance,
                     index,
                     &level_asset_path,
-                    load_context,
+                    &mut level_load_context,
                     project_context,
                     project_definition_context,
                 )
@@ -286,8 +288,9 @@ impl Level {
             location,
             layers,
             index,
-        }
-        .into();
+        };
+
+        let level = level_load_context.finish(level, None);
 
         let handle =
             load_context.add_loaded_labeled_asset(level_asset_path.to_asset_label(), level);

--- a/src/world.rs
+++ b/src/world.rs
@@ -114,6 +114,8 @@ impl World {
             &ldtk_world.levels
         };
 
+        let mut world_load_context = load_context.begin_labeled_asset();
+
         let levels = levels_iter
             .iter()
             .enumerate()
@@ -122,7 +124,7 @@ impl World {
                     ldtk_level,
                     index,
                     &world_asset_path,
-                    load_context,
+                    &mut world_load_context,
                     project_context,
                     project_definition_context,
                 )
@@ -134,8 +136,9 @@ impl World {
             iid,
             world_layout,
             levels,
-        }
-        .into();
+        };
+
+        let world = world_load_context.finish(world, None);
 
         let handle =
             load_context.add_loaded_labeled_asset(world_asset_path.to_asset_label(), world);


### PR DESCRIPTION
tested in axe_man_adventure, and against clippy.